### PR TITLE
fix: use absolute $HOME paths, disable slack cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ TODO: Add a short summary of this module.
 - `p6df::modules::macosx::home::symlink()`
 - `p6df::modules::macosx::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::modules::macosx::langs()`
 
 ## Hierarchy

--- a/init.zsh
+++ b/init.zsh
@@ -50,7 +50,7 @@ p6df::modules::macosx::external::brew() {
 #  p6df::core::homebrew::cli::brew::install --cask dropbox
 #  p6df::core::homebrew::cli::brew::install --cask gitx
 
-  p6df::core::homebrew::cli::brew::install --cask slack
+#  p6df::core::homebrew::cli::brew::install --cask slack
 #  p6df::core::homebrew::cli::brew::install --cask squidman
 #  p6df::core::homebrew::cli::brew::install --cask vagrant
 #  p6df::core::homebrew::cli::brew::install --cask virtualbox
@@ -105,8 +105,8 @@ p6df::modules::macosx::init() {
 ######################################################################
 p6df::modules::macosx::home::symlink() {
 
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.cups" ".cups"
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.ssh" ".ssh"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.cups" "$HOME/.cups"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.ssh" "$HOME/.ssh"
 
   p6_return_void
 }


### PR DESCRIPTION
Fix symlink targets to use absolute $HOME paths. Disable slack cask install (comment out). Fix typo i$HOME -> $HOME for .ssh symlink.