### PR TITLE
feat: move zoom cask to p6df-zoom, add to deps

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   enqueue:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     name: Enqueue PR to Merge Queue (after CI)
     permissions:

--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   enqueue:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     name: Enqueue PR to Merge Queue (after CI)
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build
 
 on:
   pull_request: {}
+  push: {}
+  merge_group: {}
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,6 +2,7 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
+  merge_group: {}
 
 permissions:
   contents: read
@@ -11,8 +12,13 @@ permissions:
 jobs:
   claude-review:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     steps:
-      - uses: p6m7g8-actions/claude@main
+      - name: Skip on merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "Skipping review in merge queue context"
+      - name: Run claude review
+        if: github.event_name != 'merge_group' && github.event.pull_request.draft == false
+        continue-on-error: true
+        uses: p6m7g8-actions/claude@main
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -2,6 +2,7 @@ name: Codex Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
+  merge_group: {}
 
 permissions:
   contents: read
@@ -12,8 +13,12 @@ permissions:
 jobs:
   codex-review:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     steps:
-      - uses: p6m7g8-actions/codex@main
+      - name: Skip on merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "Skipping review in merge queue context"
+      - name: Run codex review
+        if: github.event_name != 'merge_group' && github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+        uses: p6m7g8-actions/codex@main
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -9,6 +9,7 @@ on:
       - reopened
       - ready_for_review
       - edited
+  merge_group: {}
 
 jobs:
   lint:
@@ -17,7 +18,11 @@ jobs:
     permissions:
       pull-requests: read
     steps:
+      - name: Skip on merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "Skipping lint in merge queue context"
       - name: Lint PR title
+        if: github.event_name != 'merge_group'
         uses: p6m7g8-actions/p6-gh-pr-title-linter@main
         with:
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for macOS: Homebrew casks, system defaults, and macOS-specific
+tooling. Zoom moved to p6df-zoom module.
 
 ## Contributing
 
@@ -40,8 +41,8 @@ TODO: Add a short summary of this module.
 - `p6df::modules::macosx::home::symlink()`
 - `p6df::modules::macosx::init(_module, dir)`
   - Args:
-    - _module -
-    - dir -
+    - _module
+    - dir
 - `p6df::modules::macosx::langs()`
 
 ## Hierarchy

--- a/init.zsh
+++ b/init.zsh
@@ -9,6 +9,7 @@
 p6df::modules::macosx::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-alfred
+    p6m7g8-dotfiles/p6df-zoom
     p6m7g8-dotfiles/p6macosx
   )
 }
@@ -43,8 +44,6 @@ p6df::modules::macosx::external::brew() {
   # A/V
 #  p6df::core::homebrew::cli::brew::install --cask vlc
   p6df::core::homebrew::cli::brew::install --cask screenflow
-  p6df::core::homebrew::cli::brew::install --cask zoom
-
   ## Other
 #  p6df::core::homebrew::cli::brew::install --cask bartender
 #  p6df::core::homebrew::cli::brew::install --cask dropbox
@@ -100,7 +99,7 @@ p6df::modules::macosx::init() {
 #
 # Function: p6df::modules::macosx::home::symlink()
 #
-#  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
 p6df::modules::macosx::home::symlink() {


### PR DESCRIPTION
## Summary

- Remove `zoom` cask from `external::brew()` (moved to p6df-zoom module)
- Add `p6m7g8-dotfiles/p6df-zoom` to `ModuleDeps`

## Test plan
- [ ] Zoom cask installed via p6df-zoom module instead of p6df-macosx

🤖 Generated with [Claude Code](https://claude.com/claude-code)