### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -17,11 +17,11 @@ p6df::modules::macosx::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::macosx::external::brew()
+# Function: p6df::modules::macosx::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::macosx::external::brew() {
+p6df::modules::macosx::external::brews() {
 
   ## Remote Desktop Compat
   p6df::core::homebrew::cli::brew::install --cask xquartz


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly