### PR TITLE
chore(macosx): rename home::symlink to home::symlinks, add iterm2, add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+share/.ssh/
+share/.cups/

--- a/init.zsh
+++ b/init.zsh
@@ -97,15 +97,17 @@ p6df::modules::macosx::init() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::macosx::home::symlink()
+# Function: p6df::modules::macosx::home::symlinks()
 #
 #  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
-p6df::modules::macosx::home::symlink() {
+p6df::modules::macosx::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.cups" "$HOME/.cups"
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.ssh" "$HOME/.ssh"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.iterm2" "$HOME/.iterm2"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.iterm2_shell_integration.zsh" "$HOME/.iterm2_shell_integration.zsh"
 
   p6_return_void
 }


### PR DESCRIPTION
## What
Rename singular to plural, add iterm2 symlinks, create .gitignore.

## Why
Framework dispatches plural only. iterm2 files are scripts (not binaries) confirmed trackable. .ssh and .cups are sensitive/state and must be gitignored.

## Test plan
- `p6df home symlinks` recreates ~/.cups, ~/.ssh, ~/.iterm2, ~/.iterm2_shell_integration.zsh

## Dependencies
None