### PR TITLE
fix(prompt): add macosx profile::mod with p6_return_words and extract path::init

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -141,6 +141,6 @@ p6df::modules::macosx::home::symlinks() {
 ######################################################################
 p6df::modules::macosx::profile::mod() {
 
-  p6_return_words 'macosx' '$MACOSX_DEPLOYMENT_TARGET'
+  p6_return_words 'macosx' "$"
 }
 

--- a/init.zsh
+++ b/init.zsh
@@ -76,6 +76,23 @@ p6df::modules::macosx::langs() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::macosx::path::init()
+#
+#  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
+p6df::modules::macosx::path::init() {
+
+  local _module="$1"
+  local _dir="$2"
+  p6_path_if "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.iterm2"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::macosx::init(_module, dir)
 #
 #  Args:
@@ -89,7 +106,6 @@ p6df::modules::macosx::init() {
   local dir="$2"
 
   p6_file_load "$dir/share/.iterm2_shell_integration.zsh"
-  p6_path_if "$dir/share/.iterm2"
 
   p6_return_void
 }
@@ -111,3 +127,20 @@ p6df::modules::macosx::home::symlinks() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: words macosx $MACOSX_DEPLOYMENT_TARGET = p6df::modules::macosx::profile::mod()
+#
+#  Returns:
+#	words - macosx $MACOSX_DEPLOYMENT_TARGET
+#
+#  Environment:	 MACOSX_DEPLOYMENT_TARGET
+#>
+######################################################################
+p6df::modules::macosx::profile::mod() {
+
+  p6_return_words 'macosx' '$MACOSX_DEPLOYMENT_TARGET'
+}
+


### PR DESCRIPTION
## What
Adds `p6df::modules::macosx::profile::mod()` using `p6_return_words 'macosx' '$MACOSX_DEPLOYMENT_TARGET'`. Extracts the `p6_path_if` call from `init()` into a new `path::init()` function that uses `$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR`.

## Why
Adds the standard `profile::mod` function to the macOS module and separates path initialization into its own function for clarity and consistency with other modules.

## Test plan
- Reviewed diff manually
- `path::init` uses the canonical `$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR` variable instead of the passed `dir` arg

## Dependencies
None