### PR TITLE
refactor(init): remove stub profile::mod and fix path::init blank line

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -82,9 +82,9 @@ p6df::modules::macosx::langs() {
 #>
 ######################################################################
 p6df::modules::macosx::path::init() {
-
   local _module="$1"
   local _dir="$2"
+
   p6_path_if "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.iterm2"
 
   p6_return_void
@@ -127,20 +127,3 @@ p6df::modules::macosx::home::symlinks() {
 
   p6_return_void
 }
-
-######################################################################
-#<
-#
-# Function: words macosx $MACOSX_DEPLOYMENT_TARGET = p6df::modules::macosx::profile::mod()
-#
-#  Returns:
-#	words - macosx $MACOSX_DEPLOYMENT_TARGET
-#
-#  Environment:	 MACOSX_DEPLOYMENT_TARGET
-#>
-######################################################################
-p6df::modules::macosx::profile::mod() {
-
-  p6_return_words 'macosx' "$"
-}
-


### PR DESCRIPTION
## What
Remove the stub `p6df::modules::macosx::profile::mod()` function and fix blank line placement in `path::init`.

## Why
The stub function returned a malformed value (`"$"`) with no real implementation. Removing it prevents accidental usage of broken code. The blank line fix improves code style consistency.

## Test plan
- Reviewed diff confirms only the stub function block is removed and blank line is repositioned
- No callers of the removed function exist in the codebase

## Dependencies
None