### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::macosx::deps()
-#
-#>
-######################################################################
 p6df::modules::macosx::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-alfred
@@ -15,11 +9,35 @@ p6df::modules::macosx::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::macosx::external::brews()
-#
-#>
+p6df::modules::macosx::init() {
+  local _module="$1"
+  local dir="$2"
+
+  p6_file_load "$dir/share/.iterm2_shell_integration.zsh"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::macosx::path::init() {
+  local _module="$1"
+  local _dir="$2"
+
+  p6_path_if "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.iterm2"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::macosx::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.cups" "$HOME/.cups"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.ssh" "$HOME/.ssh"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.iterm2" "$HOME/.iterm2"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.iterm2_shell_integration.zsh" "$HOME/.iterm2_shell_integration.zsh"
+
+  p6_return_void
+}
 ######################################################################
 p6df::modules::macosx::external::brews() {
 
@@ -60,12 +78,6 @@ p6df::modules::macosx::external::brews() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::macosx::langs()
-#
-#>
-######################################################################
 p6df::modules::macosx::langs() {
 
   uv pip install iterm2
@@ -76,20 +88,28 @@ p6df::modules::macosx::langs() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::macosx::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::macosx::external::brews()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::macosx::langs()
+#
+#>
+######################################################################
+#<
+#
 # Function: p6df::modules::macosx::path::init()
 #
 #  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
-######################################################################
-p6df::modules::macosx::path::init() {
-  local _module="$1"
-  local _dir="$2"
-
-  p6_path_if "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.iterm2"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -101,29 +121,9 @@ p6df::modules::macosx::path::init() {
 #
 #>
 ######################################################################
-p6df::modules::macosx::init() {
-  local _module="$1"
-  local dir="$2"
-
-  p6_file_load "$dir/share/.iterm2_shell_integration.zsh"
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::macosx::home::symlinks()
 #
 #  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
-######################################################################
-p6df::modules::macosx::home::symlinks() {
-
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.cups" "$HOME/.cups"
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.ssh" "$HOME/.ssh"
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.iterm2" "$HOME/.iterm2"
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.iterm2_shell_integration.zsh" "$HOME/.iterm2_shell_integration.zsh"
-
-  p6_return_void
-}

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::macosx::deps()
+#
+#>
+######################################################################
 p6df::modules::macosx::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-alfred
@@ -8,6 +14,16 @@ p6df::modules::macosx::deps() {
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::macosx::init(_module, dir)
+#
+#  Args:
+#	_module -
+#	dir -
+#
+#>
 ######################################################################
 p6df::modules::macosx::init() {
   local _module="$1"
@@ -19,6 +35,13 @@ p6df::modules::macosx::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::macosx::path::init()
+#
+#  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
 p6df::modules::macosx::path::init() {
   local _module="$1"
   local _dir="$2"
@@ -29,6 +52,13 @@ p6df::modules::macosx::path::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::macosx::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
 p6df::modules::macosx::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-macosx/share/.cups" "$HOME/.cups"
@@ -38,6 +68,12 @@ p6df::modules::macosx::home::symlinks() {
 
   p6_return_void
 }
+######################################################################
+#<
+#
+# Function: p6df::modules::macosx::external::brews()
+#
+#>
 ######################################################################
 p6df::modules::macosx::external::brews() {
 
@@ -78,6 +114,12 @@ p6df::modules::macosx::external::brews() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::macosx::langs()
+#
+#>
+######################################################################
 p6df::modules::macosx::langs() {
 
   uv pip install iterm2
@@ -85,45 +127,3 @@ p6df::modules::macosx::langs() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::macosx::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::macosx::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::macosx::langs()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::macosx::path::init()
-#
-#  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::macosx::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::macosx::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None